### PR TITLE
fix error callback to print message rather than pointer

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -19,7 +19,7 @@ var static_geometry: StaticGeometry = undefined;
 var font: Spritesheet = undefined;
 
 fn errorCallback(err: c_int, description: [*c]const u8) callconv(.C) void {
-    panic("Error: {}\n", .{description});
+    panic("Error: {}\n", .{@as([*:0]const u8, description)});
 }
 
 fn keyCallback(win: ?*c.GLFWwindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.C) void {


### PR DESCRIPTION
x11 error message before:
```
Error: u8@7ffdfd342ee0

/home/marler8997/git/tetris/src/main.zig:22:10: 0x214b7f in errorCallback (tetris)
    panic("Error: {}\n", .{description});
...
```
x11 error message after this change:
```
Error: X11: RandR gamma ramp support seems broken

/home/marler8997/git/tetris/src/main.zig:22:10: 0x214b58 in errorCallback (tetris)
    panic("Error: {}\n", .{@as([*:0]const u8, description)});
...
```