### PR TITLE
Revert "fix build error"

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *Builder) void {
     }
 
     if (vcpkg) {
-        exe.addVcpkgPaths(.Static) catch @panic("Cannot add vcpkg paths.");
+        exe.addVcpkgPaths(.static) catch @panic("Cannot add vcpkg paths.");
     }
 
     exe.addIncludeDir("stb_image-2.22");


### PR DESCRIPTION
This reverts commit 0d47c21e3ab3f2113868a78e075ee8e4d1f20d30.

The changes were incorrect, breaking builds on zig master.