### PR TITLE
Fixes for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
+zig-out/
 tetris

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Builder = std.build.Builder;
+const Linkage = std.build.LibExeObjStep.Linkage;
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
@@ -19,13 +20,15 @@ pub fn build(b: *Builder) void {
     }
 
     if (vcpkg) {
-        exe.addVcpkgPaths(.static) catch @panic("Cannot add vcpkg paths.");
+        const linkage: Linkage = if (windows) .dynamic else .static;
+        exe.addVcpkgPaths(linkage) catch @panic("Cannot add vcpkg paths.");
     }
 
     exe.addIncludeDir("stb_image-2.22");
 
     exe.linkSystemLibrary("c");
-    exe.linkSystemLibrary("glfw");
+    const glfwLibName = if (windows) "glfw3dll" else "glfw";
+    exe.linkSystemLibrary(glfwLibName);
     exe.linkSystemLibrary("epoxy");
     exe.install();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -133,7 +133,8 @@ pub fn main2() !void {
     font.init(font_png, Tetris.font_char_width, Tetris.font_char_height) catch @panic("unable to read assets");
     defer font.deinit();
 
-    c.srand(@truncate(c_uint, @bitCast(c_ulong, c.time(null))));
+    const TimePrimitiveType = comptime if (@sizeOf(c_ulong) == 8) c_ulong else c_ulonglong;
+    c.srand(@truncate(c_uint, @bitCast(TimePrimitiveType, c.time(null))));
 
     t.resetProjection();
 


### PR DESCRIPTION
Added a fix for c_ulong being 4 bytes on Windows, while the time struct is 8 bytes (main.zig).

Set linkage to dynamic on Windows when using Vcpkg.

handle different glfw lib name on Windows.