### PR TITLE
Mark stb_image as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+stb_image-2.22/* linguist-vendored


### PR DESCRIPTION
Weirdly, the repository is marked as C but it is actually in Zig because most of the code is the stb library, so marking it as vendored so github doesn't index it.