### PR TITLE
update build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,11 +11,14 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .target = target,
     });
-    exe.addCSourceFile("stb_image-2.22/stb_image_impl.c", &[_][]const u8{"-std=c99"});
+    exe.addCSourceFile(.{
+        .file = Build.LazyPath.relative("stb_image-2.22/stb_image_impl.c"),
+        .flags = &[_][]const u8{"-std=c99"},
+    });
     //exe.use_llvm = false;
     //exe.use_lld = false;
 
-    exe.addIncludePath("stb_image-2.22");
+    exe.addIncludePath(Build.LazyPath.relative("stb_image-2.22"));
 
     exe.linkSystemLibrary("c");
     exe.linkSystemLibrary("glfw");


### PR DESCRIPTION
Greetings from a :penguin: :snowflake: :snowman_with_snow:  penguin land,

![Hello](https://media.tenor.com/u97XzGLsUFQAAAAC/private-skipper.gif)

we penguins here love your work and enthusiasm for one of the legendary arcades called "Tetris", although it is hard for penguins to learn zig, it is not nearly impossible, thanks to this repo of yours, billions of penguins are learning zig while playing "Tetris"!

while one of our penguins using our arcade machine with your software, we have encountered an error during a build phase;
![image](https://github.com/andrewrk/tetris/assets/22800416/5eaf4c0b-b5c1-4750-afb0-5637a5e454c7)

luckily, me as a Zigling graduate from Ziglings University, I was able to sort out the issue and then able to build your "Tetris" software and load it back to all of our arcade machines of :penguin: land. Now millions of penguins are happy with Zig and Tetris again.

This PR submits a fix about build.zig changes for Zig v0.11.0 (stable release)

Regards,
:penguin: :snowflake: :snowman_with_snow: salute from Penguin Land
Arcade Tetris machine chief, Penguin Edd