### PR TITLE
eliminate `@cImport` phase two: explicit translate-c package dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.zig-cache/
 /zig-out/
+/zig-pkg/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Tetris 
 
-A simple tetris clone written in
-[zig programming language](https://github.com/andrewrk/zig).
+A simple Tetris clone written in [Zig](https://ziglang.org/).
 
 ![](http://i.imgur.com/umuNndz.png)
 
@@ -18,7 +17,7 @@ A simple tetris clone written in
 
 ## Dependencies
 
- * [Zig](https://ziglang.org/)
+ * [Zig compiler](https://ziglang.org/) - version 0.16.0 or newer
  * [libepoxy](https://github.com/anholt/libepoxy)
  * [GLFW](http://www.glfw.org/)
 

--- a/build.zig
+++ b/build.zig
@@ -1,16 +1,19 @@
 const std = @import("std");
+const Translator = @import("translate_c").Translator;
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const translate_c = b.addTranslateC(.{
-        .root_source_file = b.path("src/c.h"),
+    const translate_c = b.dependency("translate_c", .{});
+
+    const translator: Translator = .init(translate_c, .{
+        .c_source_file = b.path("src/c.h"),
         .target = target,
         .optimize = optimize,
     });
-    translate_c.linkSystemLibrary("glfw", .{});
-    translate_c.linkSystemLibrary("epoxy", .{});
+    translator.linkSystemLibrary("glfw3", .{});
+    translator.linkSystemLibrary("epoxy", .{});
 
     const exe = b.addExecutable(.{
         .name = "tetris",
@@ -21,7 +24,7 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{
                     .name = "c",
-                    .module = translate_c.createModule(),
+                    .module = translator.mod,
                 },
             },
         }),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .tetris,
+    .version = "0.0.0",
+    .fingerprint = 0xbeb86dd4542d8092, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .translate_c = .{
+            .url = "git+https://codeberg.org/ziglang/translate-c#46b5609b5ac4c0a896217d1d984f3ae50e4810b5",
+            .hash = "translate_c-0.0.0-Q_BUWpf0BgAwrh5AM-acJcslN_YPEhcoCVKbbNjwuUTJ",
+        },
+    },
+    .paths = .{
+        "LICENSE",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
This one will continue to work including if and when aro is no longer shipped with zig compiler.
